### PR TITLE
Alterando URL de alimentação de dados da API

### DIFF
--- a/src/RastreioParser.php
+++ b/src/RastreioParser.php
@@ -29,7 +29,8 @@ class RastreioParser{
                     'hour'    => '/[0-9]{2}:[0-9]{2}/',
                     'date'    => '/[0-9]{2}\/[0-9]{2}\/[0-9]{4}/'
                 ],
-                'urlParser' => 'http://www2.correios.com.br/sistemas/rastreamento/newprint.cfm'
+                //'urlParser' => 'http://www2.correios.com.br/sistemas/rastreamento/newprint.cfm'
+                'urlParser' => 'https://www2.correios.com.br/sistemas/rastreamento/resultado.cfm' //nova url
             ];
         }
         


### PR DESCRIPTION
Nesse últimos dias ao utilizar o código notei que o mesmo estava dando erro, por não reconhecer os códigos de rastreio, por fim, vi que na verdade o link dos correios que alimenta a APi mudou.
Espero que ter ajudado!